### PR TITLE
Implement auth filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ docker-compose up --build
 The frontend will be available at `http://localhost:3000` after the services start. Any username/password can be used to obtain a token from the auth-service. 
 
 Swagger UI for the book-service is available at `http://localhost:8080/swagger-ui.html` when the services are running.
+
+The book-service validates incoming requests using the auth-service. Pass the token returned from `/login` or `/register` in the `Authorization` header when calling protected endpoints.

--- a/backend/book-service/app/src/main/java/com/example/bookservice/BookServiceApplication.java
+++ b/backend/book-service/app/src/main/java/com/example/bookservice/BookServiceApplication.java
@@ -2,10 +2,18 @@ package com.example.bookservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class BookServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(BookServiceApplication.class, args);
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
     }
 }

--- a/backend/book-service/app/src/main/java/com/example/bookservice/config/AuthFilter.java
+++ b/backend/book-service/app/src/main/java/com/example/bookservice/config/AuthFilter.java
@@ -1,0 +1,62 @@
+package com.example.bookservice.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class AuthFilter extends OncePerRequestFilter {
+    private final RestTemplate restTemplate;
+
+    @Value("${auth.url:http://localhost:8081}")
+    private String authUrl;
+
+    @Value("${auth.enabled:true}")
+    private boolean enabled;
+
+    public AuthFilter(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!enabled || isPublic(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = request.getHeader("Authorization");
+        if (token == null || token.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", token);
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        try {
+            restTemplate.exchange(authUrl + "/validate", HttpMethod.GET, entity, Void.class);
+        } catch (RestClientException ex) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isPublic(HttpServletRequest request) {
+        return "GET".equalsIgnoreCase(request.getMethod()) && request.getRequestURI().startsWith("/books");
+    }
+}

--- a/backend/book-service/app/src/test/java/com/example/bookservice/BookControllerTest.java
+++ b/backend/book-service/app/src/test/java/com/example/bookservice/BookControllerTest.java
@@ -14,7 +14,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
-@SpringBootTest(properties = "spring.datasource.url=jdbc:h2:mem:testdb")
+@SpringBootTest(properties = {"spring.datasource.url=jdbc:h2:mem:testdb", "auth.enabled=false"})
 @AutoConfigureMockMvc
 @TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
 class BookControllerTest {


### PR DESCRIPTION
## Summary
- add authorization filter calling auth-service
- wire RestTemplate bean for outgoing auth requests
- disable filter in tests
- clarify README about token usage

## Testing
- `./gradlew test`
- `go test ./...`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842eb0bd7308320b1b0ca68bc278776